### PR TITLE
resolved KeyError at /connect/get_token/ "given_name"

### DIFF
--- a/connect/views.py
+++ b/connect/views.py
@@ -29,7 +29,7 @@ def get_token(request):
 
   # Save the token and other information for the view in the session.
   request.session['access_token'] = access_token
-  request.session['name'] = user_info['given_name']
+  request.session['name'] = user_info['name']
   request.session['emailAddress'] = user_info['upn']  
   request.session['showSuccess'] = 'false'
   request.session['showError'] = 'false'


### PR DESCRIPTION
Hey, awesome repo! I tried to take it for a spin and kept getting an error in the get_token() view. It traced back to user_info['given_name'] not being available. Took a quick look and I only saw the following keys in user_info:

ver, amr, aud, iss, tid, name, unique_name, oid, upn, exp, iat, sub, nbf

After changing 'given_name' to 'name' everything resolved correctly. Let me know if you want this submitted another way. Thanks!
